### PR TITLE
SI prefiksi, izvucene vrednosti u apstraktnu klasu

### DIFF
--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/ElectricCircuitSolverCore.csproj
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/ElectricCircuitSolverCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>uros7251.CircuitSolver.Core</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Uros Stojkovic</Authors>
     <Product>Linear electric circuit solver</Product>
     <Description>

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/InternationalSystemOfUnits/InternationalSystemOfUnits.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/InternationalSystemOfUnits/InternationalSystemOfUnits.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+
+namespace ElectricCircuitSolverCore.InternationalSystemOfUnits
+{
+	public enum Prefix
+	{
+		Yotta = 89,
+		Zetta = 90,
+		Exa = 69,
+		Peta = 80,
+		Tera = 84,
+		Giga = 71,
+		Mega = 77,
+		Kilo = 75,
+		None,
+		Milli = 109,
+		Micro = 117,
+		Nano = 110,
+		Pico = 112,
+		Femto = 102,
+		Atto = 97,
+		Zepto = 122,
+		Yocto = 121
+	};
+	public class Prefixes
+	{
+		private static Dictionary<Prefix, double> _prefixValues = new Dictionary<Prefix, double>(){
+			{Prefix.Yotta, 1e24},
+			{Prefix.Zetta, 1e21},
+			{Prefix.Exa, 1e18},
+			{Prefix.Peta, 1e15},
+			{Prefix.Tera, 1e12},
+			{Prefix.Giga, 1e9},
+			{Prefix.Mega, 1e6},
+			{Prefix.Kilo, 1e3},
+			{Prefix.None, 1},
+			{Prefix.Milli, 1e-3},
+			{Prefix.Micro, 1e-6},
+			{Prefix.Nano, 1e-9},
+			{Prefix.Pico, 1e-12},
+			{Prefix.Femto, 1e-15},
+			{Prefix.Atto, 1e-18},
+			{Prefix.Zepto, 1e-21},
+			{Prefix.Yocto, 1e-24}
+		};
+		public static double GetPrefixValue(char prefixLetter)
+		{
+			if (prefixLetter == 'k') prefixLetter = 'K';
+			else if (prefixLetter == 'μ') prefixLetter = 'u';
+			if (Enum.IsDefined(typeof(Prefix), (int)prefixLetter))
+			{
+				Prefix prefix = (Prefix)prefixLetter;
+				return _prefixValues[prefix];
+			}
+			throw new Exception($"'{prefixLetter}' is not valid prefix.");
+		}
+		public static double GetPrefixValue(Prefix prefix)
+		{
+			return _prefixValues[prefix];
+		}
+	}
+}

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Abstract/TwoTerminalComponent.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Abstract/TwoTerminalComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
 using ElectricCircuitSolverCore.CurrentVoltageCharacteristic;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents.Abstract
@@ -10,25 +11,35 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents.Abstract
 	public abstract class TwoTerminalComponent : ITwoTerminalComponent
 	{
 		#region Attributes
-		protected LinearCurrentVoltageCharacteristic _currentVoltageCharacteristic;
+		protected LinearCurrentVoltageCharacteristic? _currentVoltageCharacteristic;
 		protected CurrentVoltageState _state;
 		protected double _omega;
+		protected Complex _value;
 		#endregion
 
 		#region Properties
-		public string Label { get; set; }
+		public string? Label { get; set; }
 		public CurrentVoltageState State { get => _state; }
 		public Complex Current { get => _state.Current; }
 		public Complex Voltage { get => _state.Voltage; }
 		public Complex Power { get => _state.Current * _state.Voltage; }
 		public abstract ComponentType Type { get; }
+		public Complex Value { get; set; }
 		#endregion
 
 		#region Constructors
-		public TwoTerminalComponent(string label)
+		public TwoTerminalComponent(string? label)
 		{
 			Label = label;
 			_omega = -1;
+		}
+		public TwoTerminalComponent(string? label, Complex value, Prefix prefix = Prefix.None) : this(label)
+		{
+			Value = value * Prefixes.GetPrefixValue(prefix);
+		}
+		public TwoTerminalComponent(string? label, Complex value , char prefix)
+		{
+			Value = value * Prefixes.GetPrefixValue(prefix);
 		}
 		#endregion
 
@@ -38,7 +49,7 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents.Abstract
 			if (_currentVoltageCharacteristic == null || _omega != omega)
 			{
 				_omega = omega;
-				_currentVoltageCharacteristic =  CalculateCurrentVoltageCharacteristic(omega);
+				_currentVoltageCharacteristic = CalculateCurrentVoltageCharacteristic(omega);
 			}
 			return _currentVoltageCharacteristic;
 		}

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Capacitor.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Capacitor.cs
@@ -4,40 +4,20 @@ using System.Collections.Generic;
 using System.Text;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class Capacitor : TwoTerminalComponents.Abstract.TwoTerminalComponent
 	{
-		#region Attributes
-		private double _capacitance;
-		#endregion
-
-		#region Constructor
-		public Capacitor(string label, double capacitance, char unit = 'n')
-			: base(label)
+		#region Constructors
+		public Capacitor(string label, double capacitance, Prefix prefix = Prefix.None) : base(label, new Complex(0,-1/capacitance), prefix)
 		{
-			_capacitance = capacitance;
-			switch (unit)
-			{
-				case 'F':
-					_capacitance *= 1e+9;
-					break;
-				case 'm':
-					_capacitance *= 1e+6;
-					break;
-				case 'u':
-					_capacitance *= 1e+3;
-					break;
-				case 'p':
-					_capacitance /= 1e+3;
-					break;
-				default:
-					break;
-			}
+		}
+		public Capacitor(string label, double capacitance, char prefix) : base(label, new Complex(0,-1/capacitance), prefix)
+		{
 		}
 		#endregion
-
 		#region Properties
 		public override ComponentType Type => ComponentType.Capacitor;
 		#endregion
@@ -47,12 +27,8 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		{
 			return omega == 0 ?
 				LinearCurrentVoltageCharacteristic.OpenCircuit() :
-				new LinearCurrentVoltageCharacteristic(true, new Complex(0, SCALE / (omega * _capacitance)), Complex.Zero);
+				new LinearCurrentVoltageCharacteristic(true, -Value/omega, Complex.Zero);
 		}
-		#endregion
-
-		#region Static attributes
-		private static readonly double SCALE = 1e+9;
 		#endregion
 	}
 }

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/IdealCurrentSource.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/IdealCurrentSource.cs
@@ -5,39 +5,31 @@ using ElectricCircuitSolverCore.CurrentVoltageCharacteristic;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Abstract;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class IdealCurrentSource : TwoTerminalComponent
 	{
-		#region Attributes
-		private Complex _amperage;
-		#endregion
-
 		#region Constructors
-		public IdealCurrentSource(string id, Complex amperage, char unit = 'A')
-			: base(id)
-		{
-			_amperage = amperage;
-			switch (unit)
-			{
-				case 'm':
-					_amperage /= 1e3;
-					break;
-				case 'u':
-					_amperage /= 1e6;
-					break;
-				case 'n':
-					_amperage /= 1e9;
-					break;
-				default:
-					break;
-			}
-		}
-		public IdealCurrentSource(string id, double magnitude, double phase, char unit = 'A')
-			: this(id, Complex.FromPolarCoordinates(magnitude, phase), unit)
-		{
 
+		public IdealCurrentSource(string label, Complex amperage, Prefix prefix = Prefix.None) : base(label, amperage, prefix)
+		{
+		}
+		public IdealCurrentSource(string label, Complex amperage, char prefix) : base(label, amperage, prefix)
+		{
+		}
+		public IdealCurrentSource(string label, double magnitude, double phase = 0, Prefix prefix = Prefix.None)
+			: this(label, Complex.FromPolarCoordinates(magnitude, phase), prefix)
+		{
+		}
+		public IdealCurrentSource(string label, double magnitude, double phase, char prefix)
+			: this(label, Complex.FromPolarCoordinates(magnitude, phase), prefix)
+		{
+		}
+		public IdealCurrentSource(string label, double magnitude, char prefix)
+			: this(label, Complex.FromPolarCoordinates(magnitude, 0), prefix)
+		{
 		}
 		#endregion
 
@@ -48,12 +40,12 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#region Methods
 		public override LinearCurrentVoltageCharacteristic CalculateCurrentVoltageCharacteristic(double omega)
 		{
-			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(false, Complex.One, _amperage);
+			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(false, Complex.One, Value);
 		}
 
 		public override TwoTerminalComponent Reverse()
 		{
-			_amperage = -_amperage;
+			Value = -Value;
 			if (_currentVoltageCharacteristic != null)
 				_currentVoltageCharacteristic = ~_currentVoltageCharacteristic;
 			return this;

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/IdealVoltageSource.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/IdealVoltageSource.cs
@@ -5,36 +5,31 @@ using ElectricCircuitSolverCore.CurrentVoltageCharacteristic;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Abstract;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class IdealVoltageSource : TwoTerminalComponent
 	{
-		#region Attributes
-		private Complex _emf;
-		#endregion
-
 		#region Constructors
-		public IdealVoltageSource(string id, Complex emf, char unit = 'V')
-			: base(id)
-		{
-			_emf = emf;
-			switch (unit)
-			{
-				case 'k':
-					_emf *= 1e3;
-					break;
-				case 'm':
-					_emf /= 1e3;
-					break;
-				default:
-					break;
-			}
-		}
-		public IdealVoltageSource(string id, double magnitude, double phase = 0, char unit = 'V')
-			: this(id, Complex.FromPolarCoordinates(magnitude, phase), unit)
-		{
 
+		public IdealVoltageSource(string label, Complex emf, Prefix prefix = Prefix.None) : base(label, emf, prefix)
+		{
+		}
+		public IdealVoltageSource(string label, Complex emf, char prefix) : base(label, emf, prefix)
+		{
+		}
+		public IdealVoltageSource(string label, double magnitude, double phase = 0, Prefix prefix = Prefix.None)
+			: this(label, Complex.FromPolarCoordinates(magnitude, phase), prefix)
+		{
+		}
+		public IdealVoltageSource(string label, double magnitude, double phase, char prefix)
+			: this(label, Complex.FromPolarCoordinates(magnitude, phase), prefix)
+		{
+		}
+		public IdealVoltageSource(string label, double magnitude, char prefix)
+			: this(label, Complex.FromPolarCoordinates(magnitude, 0), prefix)
+		{
 		}
 		#endregion
 
@@ -45,12 +40,12 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#region Methods
 		public override LinearCurrentVoltageCharacteristic CalculateCurrentVoltageCharacteristic(double omega)
 		{
-			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, Complex.Zero, _emf);
+			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, Complex.Zero, Value);
 		}
 
 		public override TwoTerminalComponent Reverse()
 		{
-			_emf = -_emf;
+			Value = -Value;
 			if (_currentVoltageCharacteristic != null)
 				_currentVoltageCharacteristic = ~_currentVoltageCharacteristic;
 			return this;

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Impedance.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Impedance.cs
@@ -4,34 +4,18 @@ using System.Collections.Generic;
 using System.Text;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class Impedance : Abstract.TwoTerminalComponent
 	{
-		#region Attributes
-		private Complex _impedance;
-		#endregion
-
 		#region Constructors
-		public Impedance(string id, Complex impedance, char unit = 'O')
-			: base(id)
+		public Impedance(string label, Complex impendace, Prefix prefix = Prefix.None) : base(label, impendace, prefix)
 		{
-			_impedance = impedance;
-			switch (unit)
-			{
-				case 'm':
-					_impedance /= 1e3;
-					break;
-				case 'k':
-					_impedance *= 1e3;
-					break;
-				case 'M':
-					_impedance *= 1e6;
-					break;
-				default:
-					break;
-			}
+		}
+		public Impedance(string label, Complex impendace, char prefix) : base(label, impendace, prefix)
+		{
 		}
 		#endregion
 
@@ -42,7 +26,7 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#region Methods
 		public override LinearCurrentVoltageCharacteristic CalculateCurrentVoltageCharacteristic(double omega)
 		{
-			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, _impedance, Complex.Zero);
+			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, omega * Value, Complex.Zero);
 		}
 		#endregion
 	}

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Inductor.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Inductor.cs
@@ -4,34 +4,19 @@ using System.Collections.Generic;
 using System.Text;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class Inductor : TwoTerminalComponents.Abstract.TwoTerminalComponent
 	{
-		#region Attributes
-		private double _inductance;
-		#endregion
+		#region Constructors
 
-		#region Constructor
-		public Inductor(string id, double inductance, char unit = 'm')
-			: base(id)
+		public Inductor(string label, double inductance, Prefix prefix = Prefix.None) : base(label, new Complex(0, inductance), prefix)
 		{
-			_inductance = inductance;
-			switch (unit)
-			{
-				case 'H':
-					_inductance *= 1e3;
-					break;
-				case 'u':
-					_inductance /= 1e3;
-					break;
-				case 'p':
-					_inductance /= 1e6;
-					break;
-				default:
-					break;
-			}
+		}
+		public Inductor(string label, double inductance, char prefix) : base(label, new Complex(0, inductance), prefix)
+		{
 		}
 		#endregion
 
@@ -44,12 +29,8 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		{
 			return omega == 0 ?
 				LinearCurrentVoltageCharacteristic.ShortCircuit() :
-				new LinearCurrentVoltageCharacteristic(true, new Complex(0, - omega * _inductance / SCALE), Complex.Zero);
+				new LinearCurrentVoltageCharacteristic(true, -Value * omega, Complex.Zero);
 		}
-		#endregion
-
-		#region Static attributes
-		private static readonly double SCALE = 1e+3;
 		#endregion
 	}
 }

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Parallel.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Parallel.cs
@@ -12,7 +12,7 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 	{
 
 		#region Attributes
-		private TwoTerminalComponent _fixedVoltageComponent;
+		private TwoTerminalComponent? _fixedVoltageComponent;
 		private List<TwoTerminalComponent> _components;
 		#endregion
 
@@ -26,8 +26,8 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#endregion
 
 		#region Constructor
-		public Parallel(string id = null)
-			: base(id)
+		public Parallel(string? label = null)
+			: base(label)
 		{
 			_fixedVoltageComponent = null;
 			_components = new List<TwoTerminalComponent>();

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Resistor.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Resistor.cs
@@ -4,34 +4,19 @@ using System.Collections.Generic;
 using System.Text;
 using System.Numerics;
 using ElectricCircuitSolverCore.TwoTerminalComponents.Interface;
+using ElectricCircuitSolverCore.InternationalSystemOfUnits;
 
 namespace ElectricCircuitSolverCore.TwoTerminalComponents
 {
 	public class Resistor : Abstract.TwoTerminalComponent
 	{
-		#region Attributes
-		private double _resistance;
-		#endregion
-
 		#region Constructors
-		public Resistor(string id, double resistance, char unit = 'O')
-			: base(id)
+
+		public Resistor(string label, double resistance, Prefix prefix = Prefix.None) : base(label, new Complex(resistance, 0), prefix)
 		{
-			_resistance = resistance;
-			switch (unit)
-			{
-				case 'm':
-					_resistance /= 1e3;
-					break;
-				case 'k':
-					_resistance *= 1e3;
-					break;
-				case 'M':
-					_resistance *= 1e6;
-					break;
-				default:
-					break;
-			}
+		}
+		public Resistor(string label, double resistance, char prefix) : base(label, new Complex(resistance, 0), prefix)
+		{
 		}
 		#endregion
 
@@ -42,7 +27,7 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#region Methods
 		public override LinearCurrentVoltageCharacteristic CalculateCurrentVoltageCharacteristic(double omega)
 		{
-			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, new Complex(-_resistance, 0), Complex.Zero);
+			return _currentVoltageCharacteristic ?? new LinearCurrentVoltageCharacteristic(true, -Value, Complex.Zero);
 		}
 		#endregion
 	}

--- a/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Series.cs
+++ b/ElectricCircuitSolverCore/ElectricCircuitSolverCore/TwoTerminalComponents/Series.cs
@@ -11,7 +11,7 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 	public class Series : TwoTerminalComponent
 	{
 		#region Attributes
-		private TwoTerminalComponent _fixedCurrentComponent;
+		private TwoTerminalComponent? _fixedCurrentComponent;
 		private List<TwoTerminalComponent> _components;
 		#endregion
 
@@ -25,8 +25,8 @@ namespace ElectricCircuitSolverCore.TwoTerminalComponents
 		#endregion
 
 		#region Constructor
-		public Series(string id = null)
-			: base(id)
+		public Series(string? label = null)
+			: base(label)
 		{
 			_fixedCurrentComponent = null;
 			_components = new List<TwoTerminalComponent>();


### PR DESCRIPTION
Dodao sam mogućnost da se dodaju svi (osim c, d, da, ha) SI prefiksi za bilo koju veličinu. Preporučujem da se izbaci mogućnost dodavanja prefiksa preko char jer plače da se desi problem zbog neograničenja char-a i biće još jednostavniji sistem bez njih u smislu manje konstruktora i metoda. 

Takođe sam izvukao otpornost, kapacitivnost, itd. iz izvedenih klasa u jedan value u apstraktnoj.

Testirao sam na primeru iz readme fajla. Nisam proverio za kondenzatore i kalemove jer sam sve živo zaboravio.